### PR TITLE
Group wise 9: jwt 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,11 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	// JWT 의존성 추가
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
 	// env 파일 사용
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }

--- a/src/main/java/wj/flab/group_wise/config/JwtAuthenticationFilter.java
+++ b/src/main/java/wj/flab/group_wise/config/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package wj.flab.group_wise.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String token = getTokenFromRequest(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/wj/flab/group_wise/config/JwtTokenProvider.java
+++ b/src/main/java/wj/flab/group_wise/config/JwtTokenProvider.java
@@ -1,0 +1,78 @@
+package wj.flab.group_wise.config;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+    private SecretKey secretKey;
+    private final long validityInMilliseconds = 3600000; // 1시간
+
+    private final UserDetailsService userDetailsService;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String createToken(String username) {
+        // java.time API 사용
+        Instant now = Instant.now();
+        Instant validity = now.plusMillis(validityInMilliseconds);
+
+        List<String> roles = Collections.singletonList("ROLE_USER");
+
+        return Jwts.builder()
+            .subject(username)
+            .claim("roles", roles)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(validity))
+            .signWith(secretKey)
+            .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(getUsername(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/wj/flab/group_wise/config/JwtTokenProvider.java
+++ b/src/main/java/wj/flab/group_wise/config/JwtTokenProvider.java
@@ -25,7 +25,7 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String secret;
     private SecretKey secretKey;
-    private final long validityInMilliseconds = 3600000; // 1시간
+    private static final long validityInMilliseconds = 3600000; // 1시간
 
     private final UserDetailsService userDetailsService;
 

--- a/src/main/java/wj/flab/group_wise/config/JwtTokenProvider.java
+++ b/src/main/java/wj/flab/group_wise/config/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
@@ -25,7 +26,7 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String secret;
     private SecretKey secretKey;
-    private static final long validityInMilliseconds = 3600000; // 1시간
+    private static final Duration validityTime = Duration.ofHours(1);
 
     private final UserDetailsService userDetailsService;
 
@@ -37,7 +38,7 @@ public class JwtTokenProvider {
     public String createToken(String username) {
         // java.time API 사용
         Instant now = Instant.now();
-        Instant validity = now.plusMillis(validityInMilliseconds);
+        Instant validity = now.plusMillis(validityTime.toMillis());
 
         List<String> roles = Collections.singletonList("ROLE_USER");
 

--- a/src/main/java/wj/flab/group_wise/config/SecurityConfig.java
+++ b/src/main/java/wj/flab/group_wise/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package wj.flab.group_wise.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/test").authenticated()
+                .requestMatchers("/api/auth/**").permitAll()
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+}

--- a/src/main/java/wj/flab/group_wise/config/SecurityConfig.java
+++ b/src/main/java/wj/flab/group_wise/config/SecurityConfig.java
@@ -20,7 +20,11 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Bean
+    /**
+     * csrf 토큰이 비활성화된 이유 : jwt 기반으로 인증을 하기 때문
+     * jwt 토큰은 쿠키가 아닌 Authorization 헤더에 담겨서 전송되기 때문에 csrf 공격에 취약하지 않습니다.
+     */
+    @Bean @SuppressWarnings("java:S4502")
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())

--- a/src/main/java/wj/flab/group_wise/controller/AuthController.java
+++ b/src/main/java/wj/flab/group_wise/controller/AuthController.java
@@ -1,0 +1,83 @@
+package wj.flab.group_wise.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wj.flab.group_wise.config.JwtTokenProvider;
+import wj.flab.group_wise.domain.Member;
+import wj.flab.group_wise.dto.JwtResponse;
+import wj.flab.group_wise.dto.LoginRequest;
+import wj.flab.group_wise.dto.SignupRequest;
+import wj.flab.group_wise.repository.MemberRepository;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest) {
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                    loginRequest.username(),
+                    loginRequest.password()
+                )
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            String token = jwtTokenProvider.createToken(userDetails.getUsername());
+
+            return ResponseEntity.ok(new JwtResponse(token));
+        } catch (AuthenticationException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid username or password");
+        }
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody SignupRequest signupRequest) {
+        if (userRepository.existsByUsername(signupRequest.username())) {
+            return ResponseEntity.badRequest().body("Username is already taken");
+        }
+
+        Member member = new Member(
+            signupRequest.username(),
+            passwordEncoder.encode(signupRequest.password())
+        );
+
+        userRepository.save(member);
+
+        return ResponseEntity.ok("User registered successfully");
+    }
+
+    @GetMapping("/test")
+    public String test() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        log.info(authentication.getName());
+        return "test";
+    }
+}

--- a/src/main/java/wj/flab/group_wise/controller/AuthController.java
+++ b/src/main/java/wj/flab/group_wise/controller/AuthController.java
@@ -2,7 +2,6 @@ package wj.flab.group_wise.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -33,12 +32,10 @@ public class AuthController {
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository userRepository;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<Object> login(@RequestBody LoginRequest loginRequest) {
         try {
             Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
@@ -59,7 +56,7 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody SignupRequest signupRequest) {
+    public ResponseEntity<String> register(@RequestBody SignupRequest signupRequest) {
         if (userRepository.existsByUsername(signupRequest.username())) {
             return ResponseEntity.badRequest().body("Username is already taken");
         }

--- a/src/main/java/wj/flab/group_wise/domain/Member.java
+++ b/src/main/java/wj/flab/group_wise/domain/Member.java
@@ -1,16 +1,36 @@
 package wj.flab.group_wise.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String name;
-    private String address; // 주소지
+
+    @Column(unique = true)
+    private String username;
+    private String password;
+    private String address;
+
+    public Member(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public Member(String username, String password, String address) {
+        this.username = username;
+        this.password = password;
+        this.address = address;
+    }
 
 }

--- a/src/main/java/wj/flab/group_wise/dto/JwtResponse.java
+++ b/src/main/java/wj/flab/group_wise/dto/JwtResponse.java
@@ -1,0 +1,5 @@
+package wj.flab.group_wise.dto;
+
+public record JwtResponse (String token) {
+    private static String type = "Bearer";
+}

--- a/src/main/java/wj/flab/group_wise/dto/LoginRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/LoginRequest.java
@@ -1,0 +1,3 @@
+package wj.flab.group_wise.dto;
+
+public record LoginRequest (String username, String password) {}

--- a/src/main/java/wj/flab/group_wise/dto/SignupRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/SignupRequest.java
@@ -1,0 +1,5 @@
+package wj.flab.group_wise.dto;
+
+public record SignupRequest (String username, String password ) {
+
+}

--- a/src/main/java/wj/flab/group_wise/repository/MemberRepository.java
+++ b/src/main/java/wj/flab/group_wise/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package wj.flab.group_wise.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import wj.flab.group_wise.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUsername(String username);
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/wj/flab/group_wise/service/MemberService.java
+++ b/src/main/java/wj/flab/group_wise/service/MemberService.java
@@ -1,0 +1,38 @@
+package wj.flab.group_wise.service;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import wj.flab.group_wise.domain.Member;
+import wj.flab.group_wise.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByUsername(username) // Member로 변경
+            .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        // 모든 사용자에게 "ROLE_USER" 권한 부여
+        List<GrantedAuthority> authorities = Collections.singletonList(
+            new SimpleGrantedAuthority("ROLE_USER")
+        );
+
+        return new org.springframework.security.core.userdetails.User(
+            member.getUsername(),
+            member.getPassword(),
+            authorities
+        );
+    }
+
+}

--- a/src/main/java/wj/flab/group_wise/util/SecretGenerator.java
+++ b/src/main/java/wj/flab/group_wise/util/SecretGenerator.java
@@ -1,10 +1,12 @@
 package wj.flab.group_wise.util;
 
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class SecretGenerator {
     public static void main(String[] args) {
         String secret = UUID.randomUUID().toString().replace("-", "");
-        System.out.println("JWT Secret: " + secret);
+        log.info("JWT Secret: {}", secret);
     }
 }

--- a/src/main/java/wj/flab/group_wise/util/SecretGenerator.java
+++ b/src/main/java/wj/flab/group_wise/util/SecretGenerator.java
@@ -1,0 +1,10 @@
+package wj.flab.group_wise.util;
+
+import java.util.UUID;
+
+public class SecretGenerator {
+    public static void main(String[] args) {
+        String secret = UUID.randomUUID().toString().replace("-", "");
+        System.out.println("JWT Secret: " + secret);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
     active: local
   jpa:
     hibernate:
-#      ddl-auto: create-drop
-      ddl-auto: create
+      ddl-auto: create-drop
+#      ddl-auto: create
     properties:
       hibernate:
 #        show_sql: true
@@ -21,9 +21,14 @@ logging:
       springframework:
         web: debug        # 웹 요청/응답 로깅
         security: debug   # 스프링 시큐리티 로깅
+        jdbc: debug       # JDBC 로깅
       hibernate:
         SQL: debug       # 실행되는 모든 SQL문 출력
         orm.jdbc.bind: trace  # 바인딩 파라미터 출력
     jdbc:
         connection: debug
+    com.zaxxer.hikari: DEBUG
 
+
+jwt:
+  secret: 07c32ce0bb274e139540f656d892f0e6


### PR DESCRIPTION
작업내용 :
-   cluade ai의 도움을 받아서 SecurityConfig, JwtAuthenticationFilter 등을 작성했습니다. 
-   작성한 코드가 인증 과정에서 크게 어떤 역할을 하는지는 이해할 수 있었지만, spring security 에서 AuthenticationManager 등의 객체 역할과 authenticationManager.authenticate 메서드 흐름이 잘 기억나지 않아서 다시 학습해야합니다. 
-   회원의 ROLE은 인가에 관한 것이라고 알고 있지만 사용하려면 더 학습이 필요합니다.
-   postman 으로 회원등록 후, 로그인을 하고, 로그인시 받은 토큰으로 보호받는 엔드포인트에 접근하는 것까지 테스트 해보았습니다. 

작성 클래스 상세:

- 이전 브랜치를 아직 main에 merge 하지 않아서, jwt 관련해서 새로 작성한 파일 이외에 이전 변경내용까지 뜨고 있습니다. 
- 맨 마지막 커밋 내역만 봐주시면 됩니다!
- JWT 기반의 API나 Stateless 서비스에서는 CSRF 보호를 비활성화하는 것이 일반적이라는 AI 가이드대로 CSRF 를 disabled 처리했는데 sonarqubecloud 퀄리티 체크에 실패했습니다. 이 경고는 무시해도 될까요? CSRF 공격은 참고자료를 보고 이해했고 jwt 인증을 할 경우 csrf 가 필요 없는 점도 이해했습니다.

  