### PR TITLE
Group wise 23 : 공동구매 관련 알림 서비스

### DIFF
--- a/src/main/java/wj/flab/group_wise/controller/AuthController.java
+++ b/src/main/java/wj/flab/group_wise/controller/AuthController.java
@@ -13,7 +13,7 @@ import wj.flab.group_wise.dto.CreateResponse;
 import wj.flab.group_wise.dto.JwtResponse;
 import wj.flab.group_wise.dto.member.MemberCreateRequest;
 import wj.flab.group_wise.dto.member.MemberLoginRequest;
-import wj.flab.group_wise.service.MemberService;
+import wj.flab.group_wise.service.domain.MemberService;
 
 @RestController
 @RequestMapping("/api/auth")

--- a/src/main/java/wj/flab/group_wise/controller/GroupPurchaseController.java
+++ b/src/main/java/wj/flab/group_wise/controller/GroupPurchaseController.java
@@ -17,14 +17,14 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
 import wj.flab.group_wise.domain.groupPurchase.command.GroupPurchaseOrderModifyCommand;
 import wj.flab.group_wise.dto.CreateResponse;
-import wj.flab.group_wise.dto.gropPurchase.GroupPurchaseCreateRequest;
-import wj.flab.group_wise.dto.gropPurchase.GroupPurchaseJoinRequest;
-import wj.flab.group_wise.dto.gropPurchase.GroupPurchaseUpdateRequest;
-import wj.flab.group_wise.dto.gropPurchase.GroupPurchaseWishRequest;
-import wj.flab.group_wise.dto.gropPurchase.order.AddOrderRequest;
-import wj.flab.group_wise.dto.gropPurchase.order.DeleteOrderRequest;
-import wj.flab.group_wise.dto.gropPurchase.order.ModifyOrderQuantityRequest;
-import wj.flab.group_wise.service.GroupPurchaseService;
+import wj.flab.group_wise.dto.groupPurchase.GroupPurchaseCreateRequest;
+import wj.flab.group_wise.dto.groupPurchase.GroupPurchaseJoinRequest;
+import wj.flab.group_wise.dto.groupPurchase.GroupPurchaseUpdateRequest;
+import wj.flab.group_wise.dto.groupPurchase.GroupPurchaseWishRequest;
+import wj.flab.group_wise.dto.groupPurchase.order.AddOrderRequest;
+import wj.flab.group_wise.dto.groupPurchase.order.DeleteOrderRequest;
+import wj.flab.group_wise.dto.groupPurchase.order.ModifyOrderQuantityRequest;
+import wj.flab.group_wise.service.domain.GroupPurchaseService;
 
 @RestController
 @RequestMapping("/api/group-purchases")

--- a/src/main/java/wj/flab/group_wise/controller/MemberController.java
+++ b/src/main/java/wj/flab/group_wise/controller/MemberController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import wj.flab.group_wise.domain.Member;
 import wj.flab.group_wise.dto.member.MemberResponse;
-import wj.flab.group_wise.service.MemberService;
+import wj.flab.group_wise.service.domain.MemberService;
 
 @RestController
 @RequestMapping("/api/members")

--- a/src/main/java/wj/flab/group_wise/controller/ProductController.java
+++ b/src/main/java/wj/flab/group_wise/controller/ProductController.java
@@ -16,7 +16,7 @@ import wj.flab.group_wise.dto.product.request.ProductDetailUpdateRequest;
 import wj.flab.group_wise.dto.product.request.ProductStockAddRequest;
 import wj.flab.group_wise.dto.product.request.ProductStockSetRequest;
 import wj.flab.group_wise.dto.product.response.ProductViewResponse;
-import wj.flab.group_wise.service.ProductService;
+import wj.flab.group_wise.service.domain.ProductService;
 
 @RestController
 @RequestMapping("/api/v1/products")

--- a/src/main/java/wj/flab/group_wise/domain/DeliveryChannelSetConverter.java
+++ b/src/main/java/wj/flab/group_wise/domain/DeliveryChannelSetConverter.java
@@ -1,0 +1,36 @@
+package wj.flab.group_wise.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import wj.flab.group_wise.domain.Notification.DeliveryChannel;
+
+@Converter
+public class DeliveryChannelSetConverter implements AttributeConverter<Set<DeliveryChannel>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(Set<DeliveryChannel> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        return attribute.stream()
+            .map(DeliveryChannel::name)
+            .collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public Set<DeliveryChannel> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(dbData.split(DELIMITER))
+            .map(String::trim)
+            .map(DeliveryChannel::valueOf)
+            .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/wj/flab/group_wise/domain/Member.java
+++ b/src/main/java/wj/flab/group_wise/domain/Member.java
@@ -18,17 +18,17 @@ public class Member extends BaseTimeEntity {
     private Long id;
 
     @Column(unique = true)
-    private String username;
+    private String email; // email 로 변경하자
     private String password;
     private String address;
 
-    public Member(String username, String password) {
-        this.username = username;
+    public Member(String email, String password) {
+        this.email = email;
         this.password = password;
     }
 
-    public Member(String username, String password, String address) {
-        this.username = username;
+    public Member(String email, String password, String address) {
+        this.email = email;
         this.password = password;
         this.address = address;
     }

--- a/src/main/java/wj/flab/group_wise/domain/Notification.java
+++ b/src/main/java/wj/flab/group_wise/domain/Notification.java
@@ -7,6 +7,8 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,11 +18,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseTimeEntity {
 
-    enum NotificationType {
+    public enum NotificationType {
         SUCCESS, FAILURE, MINIMUM_MET, MINIMUM_UNMET, START, CANCEL;
     }
 
-    @Id @GeneratedValue(strategy = IDENTITY)
+    public enum DeliveryChannel {
+        EMAIL, SMS, PUSH;
+    }
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
     private Long memberId;
     private Long groupPurchaseId;
@@ -33,4 +40,22 @@ public class Notification extends BaseTimeEntity {
 
     private boolean isRead;
     private String deliveredChannels;
+
+    public Notification(
+        Long groupPurchaseId, NotificationType notificationType,
+        String title, String message,
+        Long memberId, DeliveryChannel... deliveredChannels) {
+
+        this.groupPurchaseId = groupPurchaseId;
+        this.notificationType = notificationType;
+        this.title = title;
+        this.message = message;
+        this.memberId = memberId;
+        this.isRead = false;
+        this.deliveredChannels = deliveredChannels != null && deliveredChannels.length > 0
+            ? Arrays.stream(deliveredChannels)
+            .map(DeliveryChannel::name)
+            .collect(Collectors.joining(","))
+            : DeliveryChannel.EMAIL.name();
+    }
 }

--- a/src/main/java/wj/flab/group_wise/domain/Notification.java
+++ b/src/main/java/wj/flab/group_wise/domain/Notification.java
@@ -1,0 +1,32 @@
+package wj.flab.group_wise.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    enum NotificationType {
+        SUCCESS, FAILURE, MINIMUM_MET, MINIMUM_UNMET, START, CANCEL;
+    }
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+    private Long memberId;
+    private Long groupPurchaseId;
+
+    private String title;
+    private String message;
+    private NotificationType notificationType;
+
+    private boolean isRead;
+    private String deliveredChannels;
+}

--- a/src/main/java/wj/flab/group_wise/domain/Notification.java
+++ b/src/main/java/wj/flab/group_wise/domain/Notification.java
@@ -2,13 +2,13 @@ package wj.flab.group_wise.domain;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import java.util.Arrays;
-import java.util.stream.Collectors;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -39,12 +39,14 @@ public class Notification extends BaseTimeEntity {
     private NotificationType notificationType;
 
     private boolean isRead;
-    private String deliveredChannels;
+
+    @Convert(converter = DeliveryChannelSetConverter.class)
+    private Set<DeliveryChannel> deliveredChannels;
 
     public Notification(
         Long groupPurchaseId, NotificationType notificationType,
         String title, String message,
-        Long memberId, DeliveryChannel... deliveredChannels) {
+        Long memberId, Set<DeliveryChannel> deliveredChannels) {
 
         this.groupPurchaseId = groupPurchaseId;
         this.notificationType = notificationType;
@@ -52,10 +54,6 @@ public class Notification extends BaseTimeEntity {
         this.message = message;
         this.memberId = memberId;
         this.isRead = false;
-        this.deliveredChannels = deliveredChannels != null && deliveredChannels.length > 0
-            ? Arrays.stream(deliveredChannels)
-            .map(DeliveryChannel::name)
-            .collect(Collectors.joining(","))
-            : DeliveryChannel.EMAIL.name();
+        this.deliveredChannels = deliveredChannels;
     }
 }

--- a/src/main/java/wj/flab/group_wise/domain/Notification.java
+++ b/src/main/java/wj/flab/group_wise/domain/Notification.java
@@ -3,6 +3,8 @@ package wj.flab.group_wise.domain;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
@@ -25,6 +27,8 @@ public class Notification extends BaseTimeEntity {
 
     private String title;
     private String message;
+
+    @Enumerated(EnumType.STRING)
     private NotificationType notificationType;
 
     private boolean isRead;

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/GroupPurchase.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/GroupPurchase.java
@@ -151,10 +151,7 @@ public class GroupPurchase extends BaseTimeEntity {
             status = Status.COMPLETED_SUCCESS;
         }
 
-        // todo 완료 이벤트 발생
-        // - 참여자에게 알림
-        // - 성공시 주문 객체 생성
-
+        // todo 성공시 주문 객체 생성
         return status;
     }
 

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/GroupPurchase.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/GroupPurchase.java
@@ -221,4 +221,18 @@ public class GroupPurchase extends BaseTimeEntity {
             ));
     }
 
+    public List<Long> getParticipantIds() {
+        return groupPurchaseMembers.stream()
+            .filter(GroupPurchaseMember::isHasParticipated)
+            .map(GroupPurchaseMember::getMemberId)
+            .toList();
+    }
+
+    public List<Long> getWishlistIds() {
+        return groupPurchaseMembers.stream()
+            .filter(GroupPurchaseMember::isWishlist)
+            .map(GroupPurchaseMember::getMemberId)
+            .toList();
+    }
+
 }

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/command/GroupPurchaseOrderModifyCommand.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/command/GroupPurchaseOrderModifyCommand.java
@@ -3,9 +3,9 @@ package wj.flab.group_wise.domain.groupPurchase.command;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
-import wj.flab.group_wise.dto.gropPurchase.order.AddOrderRequest;
-import wj.flab.group_wise.dto.gropPurchase.order.DeleteOrderRequest;
-import wj.flab.group_wise.dto.gropPurchase.order.ModifyOrderQuantityRequest;
+import wj.flab.group_wise.dto.groupPurchase.order.AddOrderRequest;
+import wj.flab.group_wise.dto.groupPurchase.order.DeleteOrderRequest;
+import wj.flab.group_wise.dto.groupPurchase.order.ModifyOrderQuantityRequest;
 
 /*
 ## use = JsonTypeInfo.Id.NAME:

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/GroupPurchaseEvent.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/GroupPurchaseEvent.java
@@ -1,0 +1,16 @@
+package wj.flab.group_wise.domain.groupPurchase.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+
+@Getter
+public abstract class GroupPurchaseEvent extends ApplicationEvent {
+
+    private final GroupPurchase groupPurchase;
+
+    public GroupPurchaseEvent(Object source, GroupPurchase groupPurchase) {
+        super(source);
+        this.groupPurchase = groupPurchase;
+    }
+}

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/GroupPurchaseFailureEvent.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/GroupPurchaseFailureEvent.java
@@ -1,0 +1,10 @@
+package wj.flab.group_wise.domain.groupPurchase.event;
+
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+
+public class GroupPurchaseFailureEvent extends GroupPurchaseEvent {
+
+    public GroupPurchaseFailureEvent(Object source, GroupPurchase groupPurchase) {
+        super(source, groupPurchase);
+    }
+}

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/GroupPurchaseStartedEvent.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/GroupPurchaseStartedEvent.java
@@ -1,0 +1,10 @@
+package wj.flab.group_wise.domain.groupPurchase.event;
+
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+
+public class GroupPurchaseStartedEvent extends GroupPurchaseEvent {
+
+    public GroupPurchaseStartedEvent(Object source, GroupPurchase groupPurchase) {
+        super(source, groupPurchase);
+    }
+}

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/GroupPurchaseSuccessEvent.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/GroupPurchaseSuccessEvent.java
@@ -1,0 +1,10 @@
+package wj.flab.group_wise.domain.groupPurchase.event;
+
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+
+public class GroupPurchaseSuccessEvent extends GroupPurchaseEvent {
+
+    public GroupPurchaseSuccessEvent(Object source, GroupPurchase groupPurchase) {
+        super(source, groupPurchase);
+    }
+}

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/MinimumParticipantsMetEvent.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/MinimumParticipantsMetEvent.java
@@ -1,0 +1,10 @@
+package wj.flab.group_wise.domain.groupPurchase.event;
+
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+
+public class MinimumParticipantsMetEvent extends GroupPurchaseEvent {
+
+    public MinimumParticipantsMetEvent(Object source, GroupPurchase groupPurchase) {
+        super(source, groupPurchase);
+    }
+}

--- a/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/MinimumParticipantsUnmetEvent.java
+++ b/src/main/java/wj/flab/group_wise/domain/groupPurchase/event/MinimumParticipantsUnmetEvent.java
@@ -1,0 +1,10 @@
+package wj.flab.group_wise.domain.groupPurchase.event;
+
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+
+public class MinimumParticipantsUnmetEvent extends GroupPurchaseEvent {
+
+    public MinimumParticipantsUnmetEvent(Object source, GroupPurchase groupPurchase) {
+        super(source, groupPurchase);
+    }
+}

--- a/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseCreateRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseCreateRequest.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.dto.gropPurchase;
+package wj.flab.group_wise.dto.groupPurchase;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseJoinRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseJoinRequest.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.dto.gropPurchase;
+package wj.flab.group_wise.dto.groupPurchase;
 
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Range;

--- a/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseResponse.java
+++ b/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseResponse.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.dto.gropPurchase;
+package wj.flab.group_wise.dto.groupPurchase;
 
 import java.time.LocalDateTime;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;

--- a/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseUpdateRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseUpdateRequest.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.dto.gropPurchase;
+package wj.flab.group_wise.dto.groupPurchase;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseWishRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/groupPurchase/GroupPurchaseWishRequest.java
@@ -1,3 +1,3 @@
-package wj.flab.group_wise.dto.gropPurchase;
+package wj.flab.group_wise.dto.groupPurchase;
 
 public record GroupPurchaseWishRequest (boolean wish) {}

--- a/src/main/java/wj/flab/group_wise/dto/groupPurchase/order/AddOrderRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/groupPurchase/order/AddOrderRequest.java
@@ -1,13 +1,14 @@
-package wj.flab.group_wise.dto.gropPurchase.order;
+package wj.flab.group_wise.dto.groupPurchase.order;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
 import wj.flab.group_wise.domain.groupPurchase.command.GroupPurchaseOrderModifyCommand;
-@JsonTypeName("DeleteOrderRequest")
-public record DeleteOrderRequest(Long productStockId) implements GroupPurchaseOrderModifyCommand {
+
+@JsonTypeName("AddOrderRequest")
+public record AddOrderRequest(Long productStockId, Integer quantity) implements GroupPurchaseOrderModifyCommand {
 
     @Override
     public void execute(GroupPurchase groupPurchase, Long memberId) {
-        groupPurchase.deleteOrder(memberId, productStockId);
+        groupPurchase.addItem(memberId, productStockId, quantity);
     }
 }

--- a/src/main/java/wj/flab/group_wise/dto/groupPurchase/order/DeleteOrderRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/groupPurchase/order/DeleteOrderRequest.java
@@ -1,14 +1,13 @@
-package wj.flab.group_wise.dto.gropPurchase.order;
+package wj.flab.group_wise.dto.groupPurchase.order;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
 import wj.flab.group_wise.domain.groupPurchase.command.GroupPurchaseOrderModifyCommand;
-
-@JsonTypeName("AddOrderRequest")
-public record AddOrderRequest(Long productStockId, Integer quantity) implements GroupPurchaseOrderModifyCommand {
+@JsonTypeName("DeleteOrderRequest")
+public record DeleteOrderRequest(Long productStockId) implements GroupPurchaseOrderModifyCommand {
 
     @Override
     public void execute(GroupPurchase groupPurchase, Long memberId) {
-        groupPurchase.addItem(memberId, productStockId, quantity);
+        groupPurchase.deleteOrder(memberId, productStockId);
     }
 }

--- a/src/main/java/wj/flab/group_wise/dto/groupPurchase/order/ModifyOrderQuantityRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/groupPurchase/order/ModifyOrderQuantityRequest.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.dto.gropPurchase.order;
+package wj.flab.group_wise.dto.groupPurchase.order;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;

--- a/src/main/java/wj/flab/group_wise/dto/member/MemberCreateRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/member/MemberCreateRequest.java
@@ -3,7 +3,7 @@ package wj.flab.group_wise.dto.member;
 import jakarta.validation.constraints.NotBlank;
 
 public record MemberCreateRequest (
-    @NotBlank String username,
+    @NotBlank String email,
     @NotBlank String password,
     @NotBlank String address
 ) { }

--- a/src/main/java/wj/flab/group_wise/dto/member/MemberLoginRequest.java
+++ b/src/main/java/wj/flab/group_wise/dto/member/MemberLoginRequest.java
@@ -1,3 +1,3 @@
 package wj.flab.group_wise.dto.member;
 
-public record MemberLoginRequest(String username, String password) {}
+public record MemberLoginRequest(String email, String password) {}

--- a/src/main/java/wj/flab/group_wise/dto/member/MemberResponse.java
+++ b/src/main/java/wj/flab/group_wise/dto/member/MemberResponse.java
@@ -4,14 +4,14 @@ import wj.flab.group_wise.domain.Member;
 
 public record MemberResponse(
     Long id,
-    String username,
+    String email,
     String address
 ) {
 
     public static MemberResponse from(Member member) {
         return new MemberResponse(
             member.getId(),
-            member.getUsername(),
+            member.getEmail(),
             member.getAddress());
     }
 }

--- a/src/main/java/wj/flab/group_wise/repository/GroupPurchaseRepository.java
+++ b/src/main/java/wj/flab/group_wise/repository/GroupPurchaseRepository.java
@@ -1,11 +1,13 @@
 package wj.flab.group_wise.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase.Status;
 
 @Repository
 public interface GroupPurchaseRepository extends JpaRepository<GroupPurchase, Long> {
@@ -17,4 +19,6 @@ public interface GroupPurchaseRepository extends JpaRepository<GroupPurchase, Lo
         @Param("status") GroupPurchase.Status status,
         @Param("productId") Long productId);
 
+    List<GroupPurchase> findByStatusAndEndDateBefore(Status status, LocalDateTime now);
 }
+

--- a/src/main/java/wj/flab/group_wise/repository/MemberRepository.java
+++ b/src/main/java/wj/flab/group_wise/repository/MemberRepository.java
@@ -7,6 +7,6 @@ import wj.flab.group_wise.domain.Member;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByUsername(String username);
-    boolean existsByUsername(String username);
+    Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/wj/flab/group_wise/repository/NotificationRepository.java
+++ b/src/main/java/wj/flab/group_wise/repository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package wj.flab.group_wise.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import wj.flab.group_wise.domain.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+}

--- a/src/main/java/wj/flab/group_wise/service/domain/CustomUserDetailsService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/CustomUserDetailsService.java
@@ -22,9 +22,9 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByUsername(username) // Member로 변경
-            .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email) // Member로 변경
+            .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
 
         // 모든 사용자에게 "ROLE_USER" 권한 부여
         List<GrantedAuthority> authorities = Collections.singletonList(
@@ -32,7 +32,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         );
 
         return new org.springframework.security.core.userdetails.User(
-            member.getUsername(),
+            member.getEmail(),
             member.getPassword(),
             authorities
         );

--- a/src/main/java/wj/flab/group_wise/service/domain/CustomUserDetailsService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.service;
+package wj.flab.group_wise.service.domain;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/wj/flab/group_wise/service/domain/GroupPurchaseSchedulerService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/GroupPurchaseSchedulerService.java
@@ -1,0 +1,41 @@
+package wj.flab.group_wise.service.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase.Status;
+import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseFailureEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseSuccessEvent;
+import wj.flab.group_wise.repository.GroupPurchaseRepository;
+import wj.flab.group_wise.service.event.GroupPurchaseEventPublisher;
+
+@Service
+@RequiredArgsConstructor
+@EnableScheduling
+public class GroupPurchaseSchedulerService {
+
+    private final GroupPurchaseRepository groupPurchaseRepository;
+    private final GroupPurchaseEventPublisher eventPublisher;
+
+    @Scheduled(fixedDelay = 60000) // 1분마다 실행
+    public void checkAndUpdateGroupPurchaseStatus() {
+        LocalDateTime now = LocalDateTime.now();
+        List<GroupPurchase> expiredGroupPurchases = groupPurchaseRepository
+            .findByStatusAndEndDateBefore(Status.ONGOING, now);
+
+        for (GroupPurchase groupPurchase : expiredGroupPurchases) {
+            Status newStatus = groupPurchase.complete(); // 현재 상태 변경 로직이 이미 있음
+
+            // 이벤트 발행
+            if (newStatus == Status.COMPLETED_SUCCESS) {
+                eventPublisher.publishSuccessEvent(new GroupPurchaseSuccessEvent(this, groupPurchase));
+            } else if (newStatus == Status.COMPLETED_FAILURE) {
+                eventPublisher.publishFailureEvent(new GroupPurchaseFailureEvent(this, groupPurchase));
+            }
+        }
+    }
+}

--- a/src/main/java/wj/flab/group_wise/service/domain/GroupPurchaseSchedulerService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/GroupPurchaseSchedulerService.java
@@ -28,9 +28,8 @@ public class GroupPurchaseSchedulerService {
             .findByStatusAndEndDateBefore(Status.ONGOING, now);
 
         for (GroupPurchase groupPurchase : expiredGroupPurchases) {
-            Status newStatus = groupPurchase.complete(); // 현재 상태 변경 로직이 이미 있음
+            Status newStatus = groupPurchase.complete();
 
-            // 이벤트 발행
             if (newStatus == Status.COMPLETED_SUCCESS) {
                 eventPublisher.publishSuccessEvent(new GroupPurchaseSuccessEvent(this, groupPurchase));
             } else if (newStatus == Status.COMPLETED_FAILURE) {

--- a/src/main/java/wj/flab/group_wise/service/domain/MemberService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/MemberService.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.service;
+package wj.flab.group_wise.service.domain;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/src/main/java/wj/flab/group_wise/service/domain/MemberService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/MemberService.java
@@ -39,13 +39,13 @@ public class MemberService {
 
     public Long registerMember(MemberCreateRequest memberCreateRequest) {
 
-        if (memberRepository.existsByUsername(memberCreateRequest.username())) {
+        if (memberRepository.existsByEmail(memberCreateRequest.email())) {
             throw new AlreadyExistsException(TargetEntity.MEMBER,
-                memberCreateRequest.username() + "는 이미 존재하는 사용자입니다.");
+                memberCreateRequest.email() + "는 이미 존재하는 사용자입니다.");
         }
 
         Member member = new Member(
-            memberCreateRequest.username(),
+            memberCreateRequest.email(),
             passwordEncoder.encode(memberCreateRequest.password()),
             memberCreateRequest.address()
         );
@@ -58,7 +58,7 @@ public class MemberService {
         try {
             Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
-                    memberLoginRequest.username(),
+                    memberLoginRequest.email(),
                     memberLoginRequest.password()
                 )
             );

--- a/src/main/java/wj/flab/group_wise/service/domain/NotificationService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/NotificationService.java
@@ -1,49 +1,29 @@
 package wj.flab.group_wise.service.domain;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wj.flab.group_wise.domain.Member;
+import wj.flab.group_wise.domain.Notification;
+import wj.flab.group_wise.repository.NotificationRepository;
 
+@Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final MemberService memberService;
+    private final NotificationRepository notificationRepository;
 //    private final EmailService emailService;
-//    private final SMSService smsService;
 
-    public void notifyMembers(List<Long> memberIds, String title, String message) {
-        memberIds.forEach(memberId -> notifyMember(memberId, title, message));
+    public void notify(Notification notification) {
+        String title = notification.getTitle();
+        String message = notification.getMessage();
+        Member member = memberService.findMember(notification.getMemberId());
+
+//            emailService.sendEmail(member.getEmail(), title, message);
+        notificationRepository.save(notification);
     }
-
-    public void notifyMember(Long memberId, String title, String message) {
-        Member member = memberService.findMember(memberId);
-
-//        // 이메일 알림
-//        emailService.sendEmail(member.getEmail(), title, message);
-//
-//        // SMS 알림 (전화번호가 있는 경우)
-//        if (member.getPhoneNumber() != null) {
-//            smsService.sendSMS(member.getPhoneNumber(), message);
-//        }
-
-        // 웹 알림 저장 (사용자가 웹사이트에 접속했을 때 보여줄 알림)
-//        saveWebNotification(member, title, message, groupPurchase.getId());
-
-    }
-
-
-//    private void saveWebNotification(Member member, String title, String message, Long groupPurchaseId) {
-//        // 데이터베이스에 알림 정보 저장
-//        Notification notification = new Notification();
-//        notification.setMember(member);
-//        notification.setTitle(title);
-//        notification.setMessage(message);
-//        notification.setGroupPurchaseId(groupPurchaseId);
-//        notification.setCreatedAt(LocalDateTime.now());
-//        notification.setRead(false);
-//
-//        notificationRepository.save(notification);
-//    }
 }

--- a/src/main/java/wj/flab/group_wise/service/domain/NotificationService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/NotificationService.java
@@ -1,10 +1,9 @@
-package wj.flab.group_wise.service.event;
+package wj.flab.group_wise.service.domain;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import wj.flab.group_wise.domain.Member;
-import wj.flab.group_wise.service.domain.MemberService;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/wj/flab/group_wise/service/domain/ProductService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/ProductService.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.service;
+package wj.flab.group_wise.service.domain;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/wj/flab/group_wise/service/domain/ProductValidator.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/ProductValidator.java
@@ -1,4 +1,4 @@
-package wj.flab.group_wise.service;
+package wj.flab.group_wise.service.domain;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
+++ b/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
@@ -1,0 +1,77 @@
+package wj.flab.group_wise.service.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
+import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseFailureEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseStartedEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseSuccessEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.MinimumParticipantsMetEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.MinimumParticipantsUnmetEvent;
+
+@Component
+@RequiredArgsConstructor
+public class GroupPurchaseEventListener {
+    private final NotificationService notificationService;
+
+    @EventListener
+    public void handleGroupPurchaseStartedEvent(GroupPurchaseStartedEvent event) {
+        GroupPurchase groupPurchase = event.getGroupPurchase();
+
+        notificationService.notifyMembers(
+            groupPurchase.getWishlistIds(),
+            "관심 공동구매 시작",
+            "공동구매 '" + groupPurchase.getTitle() + "' 진행이 시작되었습니다."
+        );
+    }
+
+    @EventListener
+    public void handleMinimumParticipantsMetEvent(MinimumParticipantsMetEvent event) {
+        GroupPurchase groupPurchase = event.getGroupPurchase();
+        String message = "'" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 달성했습니다!";
+
+        notificationService.notifyMembers( groupPurchase.getParticipantIds(), "공동구매 최소 인원 달성", message);
+        notificationService.notifyMembers( groupPurchase.getWishlistIds(), "관심 공동구매 최소 인원 달성", message);
+    }
+
+    // 최소 인원 미달 상태 알림 처리
+    @EventListener
+    public void handleMinimumParticipantsUnmet(MinimumParticipantsUnmetEvent event) {
+        // todo : 공동구매별로 이전에 최소 인원수 달성했었는지 여부를 확인할 수 있는 필드 추가가 필요함
+    }
+
+    @EventListener
+    public void handleGroupPurchaseSuccessEvent(GroupPurchaseSuccessEvent event) {
+        GroupPurchase groupPurchase = event.getGroupPurchase();
+        notificationService.notifyMembers(
+            groupPurchase.getParticipantIds(),
+            "공동구매 성공",
+            "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 완료되었습니다."
+        );
+
+        notificationService.notifyMembers(
+            groupPurchase.getWishlistIds(),
+            "공동구매 종료",
+            "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 종료되었습니다."
+        );
+
+        // 주문 생성 로직 추가
+    }
+
+    @EventListener
+    public void handleGroupPurchaseFailureEvent(GroupPurchaseFailureEvent event) {
+        GroupPurchase groupPurchase = event.getGroupPurchase();
+        notificationService.notifyMembers(
+            groupPurchase.getParticipantIds(),
+            "공동구매 실패",
+            "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다."
+        );
+
+        notificationService.notifyMembers(
+            groupPurchase.getWishlistIds(),
+            "공동구매 종료",
+            "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다."
+        );
+    }
+}

--- a/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
+++ b/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
@@ -3,6 +3,8 @@ package wj.flab.group_wise.service.event;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import wj.flab.group_wise.domain.Notification;
+import wj.flab.group_wise.domain.Notification.NotificationType;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
 import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseFailureEvent;
 import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseStartedEvent;
@@ -14,26 +16,57 @@ import wj.flab.group_wise.service.domain.NotificationService;
 @Component
 @RequiredArgsConstructor
 public class GroupPurchaseEventListener {
+
     private final NotificationService notificationService;
 
     @EventListener
     public void handleGroupPurchaseStartedEvent(GroupPurchaseStartedEvent event) {
-        GroupPurchase groupPurchase = event.getGroupPurchase();
 
-        notificationService.notifyMembers(
-            groupPurchase.getWishlistIds(),
-            "관심 공동구매 시작",
-            "공동구매 '" + groupPurchase.getTitle() + "' 진행이 시작되었습니다."
+        GroupPurchase groupPurchase = event.getGroupPurchase();
+        groupPurchase.getWishlistIds().forEach(wishlistId ->
+            notificationService.notify(
+                new Notification(
+                    groupPurchase.getId(),
+                    NotificationType.START,
+                    "관심 공동구매 시작",
+                    "공동구매 '" + groupPurchase.getTitle() + "' 진행이 시작되었습니다.",
+                    wishlistId
+                )
+            )
         );
     }
 
     @EventListener
     public void handleMinimumParticipantsMetEvent(MinimumParticipantsMetEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
+        Long groupPurchaseId = groupPurchase.getId();
+        Notification.NotificationType notificationType = NotificationType.MINIMUM_MET;
+        String title = "공동구매 최소 인원 달성";
         String message = "'" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 달성했습니다!";
 
-        notificationService.notifyMembers( groupPurchase.getParticipantIds(), "공동구매 최소 인원 달성", message);
-        notificationService.notifyMembers( groupPurchase.getWishlistIds(), "관심 공동구매 최소 인원 달성", message);
+        groupPurchase.getParticipantIds().forEach(participantId ->
+            notificationService.notify(
+                new Notification(
+                    groupPurchaseId,
+                    notificationType,
+                    title,
+                    message,
+                    participantId
+                )
+            )
+        );
+
+        groupPurchase.getWishlistIds().forEach(wishlistId ->
+            notificationService.notify(
+                new Notification(
+                    groupPurchaseId,
+                    notificationType,
+                    "관심" + title,
+                    message,
+                    wishlistId
+                )
+            )
+        );
     }
 
     // 최소 인원 미달 상태 알림 처리
@@ -45,16 +78,31 @@ public class GroupPurchaseEventListener {
     @EventListener
     public void handleGroupPurchaseSuccessEvent(GroupPurchaseSuccessEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
-        notificationService.notifyMembers(
-            groupPurchase.getParticipantIds(),
-            "공동구매 성공",
-            "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 완료되었습니다."
+        Long groupPurchaseId = groupPurchase.getId();
+        Notification.NotificationType notificationType = NotificationType.SUCCESS;
+
+        groupPurchase.getParticipantIds().forEach(participantId ->
+            notificationService.notify(
+                new Notification(
+                    groupPurchaseId,
+                    notificationType,
+                    "공동구매 성공",
+                    "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 완료되었습니다.",
+                    participantId
+                )
+            )
         );
 
-        notificationService.notifyMembers(
-            groupPurchase.getWishlistIds(),
-            "공동구매 종료",
-            "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 종료되었습니다."
+        groupPurchase.getWishlistIds().forEach(wishlistId ->
+            notificationService.notify(
+                new Notification(
+                    groupPurchaseId,
+                    notificationType,
+                    "관심 " + "공동구매 성공",
+                    "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 종료되었습니다.",
+                    wishlistId
+                )
+            )
         );
 
         // 주문 생성 로직 추가
@@ -63,16 +111,31 @@ public class GroupPurchaseEventListener {
     @EventListener
     public void handleGroupPurchaseFailureEvent(GroupPurchaseFailureEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
-        notificationService.notifyMembers(
-            groupPurchase.getParticipantIds(),
-            "공동구매 실패",
-            "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다."
+        Long groupPurchaseId = groupPurchase.getId();
+        Notification.NotificationType notificationType = NotificationType.FAILURE;
+
+        groupPurchase.getParticipantIds().forEach(participantId ->
+            notificationService.notify(
+                new Notification(
+                    groupPurchaseId,
+                    notificationType,
+                    "공동구매 실패",
+                    "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다.",
+                    participantId
+                )
+            )
         );
 
-        notificationService.notifyMembers(
-            groupPurchase.getWishlistIds(),
-            "공동구매 종료",
-            "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다."
+        groupPurchase.getWishlistIds().forEach(wishlistId ->
+            notificationService.notify(
+                new Notification(
+                    groupPurchaseId,
+                    notificationType,
+                    "관심 공동구매 종료",
+                    "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다.",
+                    wishlistId
+                )
+            )
         );
     }
 }

--- a/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
+++ b/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
@@ -1,9 +1,11 @@
 package wj.flab.group_wise.service.event;
 
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import wj.flab.group_wise.domain.Notification;
+import wj.flab.group_wise.domain.Notification.DeliveryChannel;
 import wj.flab.group_wise.domain.Notification.NotificationType;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
 import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseFailureEvent;
@@ -30,7 +32,8 @@ public class GroupPurchaseEventListener {
                     NotificationType.START,
                     "관심 공동구매 시작",
                     "공동구매 '" + groupPurchase.getTitle() + "' 진행이 시작되었습니다.",
-                    wishlistId
+                    wishlistId,
+                    Set.of(DeliveryChannel.EMAIL)
                 )
             )
         );
@@ -51,7 +54,8 @@ public class GroupPurchaseEventListener {
                     notificationType,
                     title,
                     message,
-                    participantId
+                    participantId,
+                    Set.of(DeliveryChannel.EMAIL)
                 )
             )
         );
@@ -63,7 +67,8 @@ public class GroupPurchaseEventListener {
                     notificationType,
                     "관심" + title,
                     message,
-                    wishlistId
+                    wishlistId,
+                    Set.of(DeliveryChannel.EMAIL)
                 )
             )
         );
@@ -88,7 +93,8 @@ public class GroupPurchaseEventListener {
                     notificationType,
                     "공동구매 성공",
                     "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 완료되었습니다.",
-                    participantId
+                    participantId,
+                    Set.of(DeliveryChannel.EMAIL)
                 )
             )
         );
@@ -100,7 +106,8 @@ public class GroupPurchaseEventListener {
                     notificationType,
                     "관심 " + "공동구매 성공",
                     "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 종료되었습니다.",
-                    wishlistId
+                    wishlistId,
+                    Set.of(DeliveryChannel.EMAIL)
                 )
             )
         );
@@ -121,7 +128,8 @@ public class GroupPurchaseEventListener {
                     notificationType,
                     "공동구매 실패",
                     "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다.",
-                    participantId
+                    participantId,
+                    Set.of(DeliveryChannel.EMAIL)
                 )
             )
         );
@@ -133,7 +141,8 @@ public class GroupPurchaseEventListener {
                     notificationType,
                     "관심 공동구매 종료",
                     "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다.",
-                    wishlistId
+                    wishlistId,
+                    Set.of(DeliveryChannel.EMAIL)
                 )
             )
         );

--- a/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
+++ b/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
@@ -9,6 +9,7 @@ import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseStartedEvent;
 import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseSuccessEvent;
 import wj.flab.group_wise.domain.groupPurchase.event.MinimumParticipantsMetEvent;
 import wj.flab.group_wise.domain.groupPurchase.event.MinimumParticipantsUnmetEvent;
+import wj.flab.group_wise.service.domain.NotificationService;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventPublisher.java
+++ b/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventPublisher.java
@@ -1,0 +1,38 @@
+package wj.flab.group_wise.service.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseFailureEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseStartedEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseSuccessEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.MinimumParticipantsMetEvent;
+import wj.flab.group_wise.domain.groupPurchase.event.MinimumParticipantsUnmetEvent;
+
+@Component
+@RequiredArgsConstructor
+public class GroupPurchaseEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publishStartEvent(GroupPurchaseStartedEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+
+    public void publishMinimumParticipantsMetEvent(MinimumParticipantsMetEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+
+    public void publishMinimumParticipantsUnmetEvent(MinimumParticipantsUnmetEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+
+    public void publishSuccessEvent(GroupPurchaseSuccessEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+
+    public void publishFailureEvent(GroupPurchaseFailureEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+
+}

--- a/src/main/java/wj/flab/group_wise/service/event/NotificationService.java
+++ b/src/main/java/wj/flab/group_wise/service/event/NotificationService.java
@@ -1,0 +1,50 @@
+package wj.flab.group_wise.service.event;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import wj.flab.group_wise.domain.Member;
+import wj.flab.group_wise.service.domain.MemberService;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final MemberService memberService;
+//    private final EmailService emailService;
+//    private final SMSService smsService;
+
+    public void notifyMembers(List<Long> memberIds, String title, String message) {
+        memberIds.forEach(memberId -> notifyMember(memberId, title, message));
+    }
+
+    public void notifyMember(Long memberId, String title, String message) {
+        Member member = memberService.findMember(memberId);
+
+//        // 이메일 알림
+//        emailService.sendEmail(member.getEmail(), title, message);
+//
+//        // SMS 알림 (전화번호가 있는 경우)
+//        if (member.getPhoneNumber() != null) {
+//            smsService.sendSMS(member.getPhoneNumber(), message);
+//        }
+
+        // 웹 알림 저장 (사용자가 웹사이트에 접속했을 때 보여줄 알림)
+//        saveWebNotification(member, title, message, groupPurchase.getId());
+
+    }
+
+
+//    private void saveWebNotification(Member member, String title, String message, Long groupPurchaseId) {
+//        // 데이터베이스에 알림 정보 저장
+//        Notification notification = new Notification();
+//        notification.setMember(member);
+//        notification.setTitle(title);
+//        notification.setMessage(message);
+//        notification.setGroupPurchaseId(groupPurchaseId);
+//        notification.setCreatedAt(LocalDateTime.now());
+//        notification.setRead(false);
+//
+//        notificationRepository.save(notification);
+//    }
+}

--- a/src/main/resources/db/migration/V3__drop_column_from_group_purchase.sql
+++ b/src/main/resources/db/migration/V3__drop_column_from_group_purchase.sql
@@ -1,0 +1,6 @@
+alter table group_purchase
+    drop column initial_price,
+    drop column current_participants,
+    add column last_minimum_participants_met_date datetime(6) null comment '마지막 최소 인원 충족 일시';
+
+

--- a/src/main/resources/db/migration/V4__create_notification_table.sql
+++ b/src/main/resources/db/migration/V4__create_notification_table.sql
@@ -1,0 +1,20 @@
+create table notification
+(
+    id                 bigint auto_increment
+        primary key,
+    member_id          bigint       not null comment '알림 수신자 ID',
+    group_purchase_id  bigint       null comment '관련 공동구매 ID',
+    title              varchar(255) not null comment '알림 제목',
+    message            text         not null comment '알림 내용',
+    notification_type  enum ('SUCCESS', 'FAILURE', 'MINIMUM_MET', 'MINIMUM_UNMET', 'START', 'CANCEL')
+                                    not null comment '알림 타입',
+    is_read            bit          not null default 0 comment '읽음 여부',
+    delivered_channels varchar(255) null comment '전송된 채널 (SMS,EMAIL,APP)',
+    created_date       datetime(6)  not null comment '알림 생성 일시',
+    modified_date      datetime(6)  null comment '최종 수정 일시',
+    constraint FK_notification__member__id
+        foreign key (member_id) references member (id),
+    constraint FK_notification__group_purchase__id
+        foreign key (group_purchase_id) references group_purchase (id)
+)
+    comment '알림 메시지';

--- a/src/main/resources/db/migration/V5__alter_member_table.sql
+++ b/src/main/resources/db/migration/V5__alter_member_table.sql
@@ -1,0 +1,2 @@
+alter table member
+    change username email varchar(255) not null comment '이메일';

--- a/src/test/java/wj/flab/group_wise/service/GroupPurchaseServiceTest.java
+++ b/src/test/java/wj/flab/group_wise/service/GroupPurchaseServiceTest.java
@@ -13,11 +13,14 @@ import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
 import wj.flab.group_wise.domain.product.Product;
 import wj.flab.group_wise.domain.product.Product.SaleStatus;
 import wj.flab.group_wise.domain.product.ProductStock;
-import wj.flab.group_wise.dto.gropPurchase.GroupPurchaseCreateRequest;
-import wj.flab.group_wise.dto.gropPurchase.GroupPurchaseJoinRequest;
-import wj.flab.group_wise.dto.gropPurchase.GroupPurchaseUpdateRequest;
+import wj.flab.group_wise.dto.groupPurchase.GroupPurchaseCreateRequest;
+import wj.flab.group_wise.dto.groupPurchase.GroupPurchaseJoinRequest;
+import wj.flab.group_wise.dto.groupPurchase.GroupPurchaseUpdateRequest;
 import wj.flab.group_wise.dto.member.MemberCreateRequest;
 import wj.flab.group_wise.dto.product.request.ProductStockSetRequest;
+import wj.flab.group_wise.service.domain.GroupPurchaseService;
+import wj.flab.group_wise.service.domain.MemberService;
+import wj.flab.group_wise.service.domain.ProductService;
 
 @SpringBootTest
 @ActiveProfiles("test")

--- a/src/test/java/wj/flab/group_wise/service/ProductServiceTest.java
+++ b/src/test/java/wj/flab/group_wise/service/ProductServiceTest.java
@@ -23,6 +23,7 @@ import wj.flab.group_wise.dto.product.request.ProductStockAddRequest.StockAddReq
 import wj.flab.group_wise.dto.product.request.ProductStockSetRequest;
 import wj.flab.group_wise.dto.product.response.ProductViewResponse;
 import wj.flab.group_wise.repository.ProductRepository;
+import wj.flab.group_wise.service.domain.ProductService;
 
 @SpringBootTest
 @ActiveProfiles("test")


### PR DESCRIPTION
### 작업내용
- 스케줄링을 통한 상태 변경 관리
  - 공동구매 시작 시점에 공동구매 상태를 '진행중'으로 변경
  - 공동구매 종료 시점에 공동구매 상태를 '종료' 관련 상태로 변경
  - 위 변경이 일어날 때 회원에게 알림
- 이벤트 구현
  - 공동구매 진행중 상태에서 참여인원이 기준인원수를 채우면 (참여/즐겨찾기)회원에게 알림
  - 공동구매 종료 상태가 될 때 
    - 인원이 기준인원을 채운 상태이면 성공적으로 종료한 사실을 (참여/즐겨찾기)회원에게 알림
    - 인원이 미달한 상태이면 회원에게 공동구매가 실패했음을 (참여/즐겨찾기)회원에게 알림
  
  ### 작업하지 못한 항목
  - emailService 는 구현하지 못했습니다. 추후 가볍게 로그라도 남길 수 있도록 해보겠습니다.
  - 공동구매 진행중 상태에서 (다시) 기준인원수를 미달하게 되면 위 회원 그룹에 모두 알림
    - 이렇게 알리려면 인원수를 충족했었던 시점이 있었는지 확인이 필요해 GroupPurchase 테이블 컬럼이 더 필요할 것 같습니다.
    - 아직 작업하지 않았습니다.
  - 공동구매 중도 취소 사실을 알림
  
  우선 중간 점검 받고자 PR 올립니다!