### PR TITLE
Group wise 30: N+1 문제 해결을 위한 배치사이즈 설정, 알림리스너 개선

### DIFF
--- a/src/main/java/wj/flab/group_wise/config/AsyncConfig.java
+++ b/src/main/java/wj/flab/group_wise/config/AsyncConfig.java
@@ -1,0 +1,66 @@
+package wj.flab.group_wise.config;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    /*
+    기본 설정(기본 TaskExecutor) 으로 실행되는 내용:
+    - 스레드 풀 크기: 무제한 (매번 새 스레드 생성)
+    - 큐 크기: 무제한
+    - 스레드 이름: task-1, task-2, task-3...
+     */
+
+    /*
+    # 아래 동작방식
+    1. 요청 1~5개: 즉시 처리 (기본 스레드 사용)
+    2. 요청 6~15개: 새 스레드 생성해서 처리
+    3. 요청 15~115: 큐에서 대기
+    4. 요청 116개 이상: RejectedExecutionException 발생 (시스템 보호)
+     */
+
+    @Bean("notificationTaskExecutor")
+    public TaskExecutor notificationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        // 기본 스레드 수 (항상 유지)
+        executor.setCorePoolSize(5);
+
+        // 최대 스레드 수 (피크 시간 대비)
+        executor.setMaxPoolSize(15);
+
+        // 대기열 크기 (급작스런 트래픽 대비)
+        // 추천: 예상 동시 요청 수 * 2
+        executor.setQueueCapacity(100);
+
+        // 스레드 이름 (디버깅용)
+        executor.setThreadNamePrefix("notification-");
+
+        // 스레드 유지 시간 (idle 스레드 정리)
+        // CorePoolSize를 초과해서 생성된 스레드들이 idle 상태일 때 얼마나 살아있을지 결정
+        executor.setKeepAliveSeconds(60);
+
+        // 애플리케이션 종료 시 처리
+        // 1. 새로운 작업 수락 중단
+        // 2. 현재 실행 중인 작업들은 완료될 때까지 대기
+        // 3. 큐에 대기 중인 작업들도 처리 완료 후 종료
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+
+        // 30초 지나도 작업이 남아있으면: 강제 종료
+        executor.setAwaitTerminationSeconds(30);
+
+        // 큐가 가득 찬 경우 정책
+        // 4가지 정책이 있음. 현재 정책은 스레드 풀이 가득 차면, Controller 스레드가 직접 알림 발송 처리
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/wj/flab/group_wise/domain/Notification.java
+++ b/src/main/java/wj/flab/group_wise/domain/Notification.java
@@ -43,7 +43,7 @@ public class Notification extends BaseTimeEntity {
     @Convert(converter = DeliveryChannelSetConverter.class)
     private Set<DeliveryChannel> deliveredChannels;
 
-    public Notification(
+    private Notification(
         Long groupPurchaseId, NotificationType notificationType,
         String title, String message,
         Long memberId, Set<DeliveryChannel> deliveredChannels) {
@@ -55,5 +55,99 @@ public class Notification extends BaseTimeEntity {
         this.memberId = memberId;
         this.isRead = false;
         this.deliveredChannels = deliveredChannels;
+    }
+
+    public static Notification createStartNotification(long groupPurchaseId, String groupPurchaseTitle, long wishMemberId) {
+        return new Notification(
+            groupPurchaseId,
+            NotificationType.START,
+            "관심 공동구매 시작",
+            "공동구매 '" + groupPurchaseTitle + "' 진행이 시작되었습니다.",
+            wishMemberId,
+            Set.of(DeliveryChannel.EMAIL)
+        );
+    }
+
+    // 최소 인원 달성 알림 (참여자용)
+    public static Notification createMinimumMetNotificationForParticipant(Long groupPurchaseId, String groupPurchaseTitle, Long memberId) {
+        return new Notification(
+            groupPurchaseId,
+            NotificationType.MINIMUM_MET,
+            "공동구매 최소 인원 달성",
+            "'" + groupPurchaseTitle + "' 공동구매가 최소 인원을 달성했습니다!",
+            memberId,
+            Set.of(DeliveryChannel.EMAIL)
+        );
+    }
+
+    // 최소 인원 달성 알림 (관심 회원용)
+    public static Notification createMinimumMetNotificationForWishlist(Long groupPurchaseId, String groupPurchaseTitle, Long memberId) {
+        return new Notification(
+            groupPurchaseId,
+            NotificationType.MINIMUM_MET,
+            "관심 공동구매 최소 인원 달성",
+            "'" + groupPurchaseTitle + "' 공동구매가 최소 인원을 달성했습니다!",
+            memberId,
+            Set.of(DeliveryChannel.EMAIL)
+        );
+    }
+
+    // 공동구매 성공 알림 (참여자용)
+    public static Notification createSuccessNotificationForParticipant(Long groupPurchaseId, String groupPurchaseTitle, Long memberId) {
+        return new Notification(
+            groupPurchaseId,
+            NotificationType.SUCCESS,
+            "공동구매 성공",
+            "참여하신 '" + groupPurchaseTitle + "' 공동구매가 성공적으로 완료되었습니다.",
+            memberId,
+            Set.of(DeliveryChannel.EMAIL)
+        );
+    }
+
+    // 공동구매 성공 알림 (관심 회원용)
+    public static Notification createSuccessNotificationForWishlist(Long groupPurchaseId, String groupPurchaseTitle, Long memberId) {
+        return new Notification(
+            groupPurchaseId,
+            NotificationType.SUCCESS,
+            "관심 공동구매 성공",
+            "관심 목록에 있는 '" + groupPurchaseTitle + "' 공동구매가 성공적으로 종료되었습니다.",
+            memberId,
+            Set.of(DeliveryChannel.EMAIL)
+        );
+    }
+
+    // 공동구매 실패 알림 (참여자용)
+    public static Notification createFailureNotificationForParticipant(Long groupPurchaseId, String groupPurchaseTitle, Long memberId) {
+        return new Notification(
+            groupPurchaseId,
+            NotificationType.FAILURE,
+            "공동구매 실패",
+            "참여하신 '" + groupPurchaseTitle + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다.",
+            memberId,
+            Set.of(DeliveryChannel.EMAIL)
+        );
+    }
+
+    // 공동구매 실패 알림 (관심 회원용)
+    public static Notification createFailureNotificationForWishlist(Long groupPurchaseId, String groupPurchaseTitle, Long memberId) {
+        return new Notification(
+            groupPurchaseId,
+            NotificationType.FAILURE,
+            "관심 공동구매 종료",
+            "관심 목록에 있는 '" + groupPurchaseTitle + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다.",
+            memberId,
+            Set.of(DeliveryChannel.EMAIL)
+        );
+    }
+
+    // 유연한 커스텀 알림 생성 (특별한 경우용)
+    public static Notification createCustomNotification(
+        Long groupPurchaseId,
+        NotificationType type,
+        String title,
+        String message,
+        Long memberId,
+        Set<DeliveryChannel> channels) {
+        return new Notification(groupPurchaseId, type, title, message, memberId, channels);
     }
 }

--- a/src/main/java/wj/flab/group_wise/service/domain/GroupPurchaseSchedulerService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/GroupPurchaseSchedulerService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase.Status;
 import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseFailureEvent;
@@ -16,6 +17,7 @@ import wj.flab.group_wise.service.event.GroupPurchaseEventPublisher;
 @Service
 @RequiredArgsConstructor
 @EnableScheduling
+@Transactional
 public class GroupPurchaseSchedulerService {
 
     private final GroupPurchaseRepository groupPurchaseRepository;

--- a/src/main/java/wj/flab/group_wise/service/domain/NotificationService.java
+++ b/src/main/java/wj/flab/group_wise/service/domain/NotificationService.java
@@ -18,12 +18,18 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 //    private final EmailService emailService;
 
-    public void notify(Notification notification) {
-        String title = notification.getTitle();
-        String message = notification.getMessage();
-        Member member = memberService.findMember(notification.getMemberId());
+    public boolean notify(Notification notification) {
+        try {
+            String title = notification.getTitle();
+            String message = notification.getMessage();
+            Member member = memberService.findMember(notification.getMemberId());
 
 //            emailService.sendEmail(member.getEmail(), title, message);
-        notificationRepository.save(notification);
+            notificationRepository.save(notification);
+            return true;
+
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
+++ b/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
@@ -1,14 +1,14 @@
 package wj.flab.group_wise.service.event;
 
-import java.util.Set;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import wj.flab.group_wise.domain.Notification;
-import wj.flab.group_wise.domain.Notification.DeliveryChannel;
-import wj.flab.group_wise.domain.Notification.NotificationType;
 import wj.flab.group_wise.domain.groupPurchase.GroupPurchase;
 import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseFailureEvent;
 import wj.flab.group_wise.domain.groupPurchase.event.GroupPurchaseStartedEvent;
@@ -19,6 +19,7 @@ import wj.flab.group_wise.service.domain.NotificationService;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class GroupPurchaseEventListener {
 
     private final NotificationService notificationService;
@@ -28,54 +29,49 @@ public class GroupPurchaseEventListener {
     public void handleGroupPurchaseStartedEvent(GroupPurchaseStartedEvent event) {
 
         GroupPurchase groupPurchase = event.getGroupPurchase();
-        groupPurchase.getWishlistIds().forEach(wishlistId ->
-            notificationService.notify(
-                new Notification(
+
+        Map<Boolean, Long> results = groupPurchase.getWishlistIds().parallelStream()
+            .map(wishlistId -> notificationService.notify(
+                Notification.createStartNotification(
                     groupPurchase.getId(),
-                    NotificationType.START,
-                    "관심 공동구매 시작",
-                    "공동구매 '" + groupPurchase.getTitle() + "' 진행이 시작되었습니다.",
-                    wishlistId,
-                    Set.of(DeliveryChannel.EMAIL)
-                )
-            )
-        );
+                    groupPurchase.getTitle(),
+                    wishlistId)))
+            .collect(Collectors.groupingBy(result -> result, Collectors.counting()));
+
+        log.info("공동구매 시작 알림 발송 완료. 성공: {}명, 실패: {}명",
+            results.getOrDefault(true, 0L), results.getOrDefault(false, 0L));
     }
 
     @Async("notificationTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMinimumParticipantsMetEvent(MinimumParticipantsMetEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
-        Long groupPurchaseId = groupPurchase.getId();
-        Notification.NotificationType notificationType = NotificationType.MINIMUM_MET;
-        String title = "공동구매 최소 인원 달성";
-        String message = "'" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 달성했습니다!";
 
-        groupPurchase.getParticipantIds().forEach(participantId ->
-            notificationService.notify(
-                new Notification(
-                    groupPurchaseId,
-                    notificationType,
-                    title,
-                    message,
-                    participantId,
-                    Set.of(DeliveryChannel.EMAIL)
+        // 참여자들에게 알림
+        Map<Boolean, Long> participantResults = groupPurchase.getParticipantIds().parallelStream()
+            .map(participantId -> notificationService.notify(
+                Notification.createMinimumMetNotificationForParticipant(
+                    groupPurchase.getId(),
+                    groupPurchase.getTitle(),
+                    participantId
                 )
-            )
-        );
+            ))
+            .collect(Collectors.groupingBy(result -> result, Collectors.counting()));
 
-        groupPurchase.getWishlistIds().forEach(wishlistId ->
-            notificationService.notify(
-                new Notification(
-                    groupPurchaseId,
-                    notificationType,
-                    "관심" + title,
-                    message,
-                    wishlistId,
-                    Set.of(DeliveryChannel.EMAIL)
+        // 관심 회원들에게 알림
+        Map<Boolean, Long> wishlistResults = groupPurchase.getWishlistIds().parallelStream()
+            .map(wishlistId -> notificationService.notify(
+                Notification.createMinimumMetNotificationForWishlist(
+                    groupPurchase.getId(),
+                    groupPurchase.getTitle(),
+                    wishlistId
                 )
-            )
-        );
+            ))
+            .collect(Collectors.groupingBy(result -> result, Collectors.counting()));
+
+        log.info("최소 인원 달성 알림 발송 완료. 참여자 성공: {}명, 실패: {}명 | 관심회원 성공: {}명, 실패: {}명",
+            participantResults.getOrDefault(true, 0L), participantResults.getOrDefault(false, 0L),
+            wishlistResults.getOrDefault(true, 0L), wishlistResults.getOrDefault(false, 0L));
     }
 
     // 최소 인원 미달 상태 알림 처리
@@ -89,34 +85,32 @@ public class GroupPurchaseEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGroupPurchaseSuccessEvent(GroupPurchaseSuccessEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
-        Long groupPurchaseId = groupPurchase.getId();
-        Notification.NotificationType notificationType = NotificationType.SUCCESS;
 
-        groupPurchase.getParticipantIds().forEach(participantId ->
-            notificationService.notify(
-                new Notification(
-                    groupPurchaseId,
-                    notificationType,
-                    "공동구매 성공",
-                    "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 완료되었습니다.",
-                    participantId,
-                    Set.of(DeliveryChannel.EMAIL)
+        // 참여자들에게 성공 알림
+        Map<Boolean, Long> participantResults = groupPurchase.getParticipantIds().parallelStream()
+            .map(participantId -> notificationService.notify(
+                Notification.createSuccessNotificationForParticipant(
+                    groupPurchase.getId(),
+                    groupPurchase.getTitle(),
+                    participantId
                 )
-            )
-        );
+            ))
+            .collect(Collectors.groupingBy(result -> result, Collectors.counting()));
 
-        groupPurchase.getWishlistIds().forEach(wishlistId ->
-            notificationService.notify(
-                new Notification(
-                    groupPurchaseId,
-                    notificationType,
-                    "관심 " + "공동구매 성공",
-                    "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 성공적으로 종료되었습니다.",
-                    wishlistId,
-                    Set.of(DeliveryChannel.EMAIL)
+        // 관심 회원들에게 성공 알림
+        Map<Boolean, Long> wishlistResults = groupPurchase.getWishlistIds().parallelStream()
+            .map(wishlistId -> notificationService.notify(
+                Notification.createSuccessNotificationForWishlist(
+                    groupPurchase.getId(),
+                    groupPurchase.getTitle(),
+                    wishlistId
                 )
-            )
-        );
+            ))
+            .collect(Collectors.groupingBy(result -> result, Collectors.counting()));
+
+        log.info("공동구매 성공 알림 발송 완료. 참여자 성공: {}명, 실패: {}명 | 관심회원 성공: {}명, 실패: {}명",
+            participantResults.getOrDefault(true, 0L), participantResults.getOrDefault(false, 0L),
+            wishlistResults.getOrDefault(true, 0L), wishlistResults.getOrDefault(false, 0L));
 
         // 주문 생성 로직 추가
     }
@@ -125,33 +119,31 @@ public class GroupPurchaseEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGroupPurchaseFailureEvent(GroupPurchaseFailureEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
-        Long groupPurchaseId = groupPurchase.getId();
-        Notification.NotificationType notificationType = NotificationType.FAILURE;
 
-        groupPurchase.getParticipantIds().forEach(participantId ->
-            notificationService.notify(
-                new Notification(
-                    groupPurchaseId,
-                    notificationType,
-                    "공동구매 실패",
-                    "참여하신 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다.",
-                    participantId,
-                    Set.of(DeliveryChannel.EMAIL)
+        // 참여자들에게 실패 알림
+        Map<Boolean, Long> participantResults = groupPurchase.getParticipantIds().parallelStream()
+            .map(participantId -> notificationService.notify(
+                Notification.createFailureNotificationForParticipant(
+                    groupPurchase.getId(),
+                    groupPurchase.getTitle(),
+                    participantId
                 )
-            )
-        );
+            ))
+            .collect(Collectors.groupingBy(result -> result, Collectors.counting()));
 
-        groupPurchase.getWishlistIds().forEach(wishlistId ->
-            notificationService.notify(
-                new Notification(
-                    groupPurchaseId,
-                    notificationType,
-                    "관심 공동구매 종료",
-                    "관심 목록에 있는 '" + groupPurchase.getTitle() + "' 공동구매가 최소 인원을 충족하지 못해 취소되었습니다.",
-                    wishlistId,
-                    Set.of(DeliveryChannel.EMAIL)
+        // 관심 회원들에게 실패 알림
+        Map<Boolean, Long> wishlistResults = groupPurchase.getWishlistIds().parallelStream()
+            .map(wishlistId -> notificationService.notify(
+                Notification.createFailureNotificationForWishlist(
+                    groupPurchase.getId(),
+                    groupPurchase.getTitle(),
+                    wishlistId
                 )
-            )
-        );
+            ))
+            .collect(Collectors.groupingBy(result -> result, Collectors.counting()));
+
+        log.info("공동구매 실패 알림 발송 완료. 참여자 성공: {}명, 실패: {}명 | 관심회원 성공: {}명, 실패: {}명",
+            participantResults.getOrDefault(true, 0L), participantResults.getOrDefault(false, 0L),
+            wishlistResults.getOrDefault(true, 0L), wishlistResults.getOrDefault(false, 0L));
     }
 }

--- a/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
+++ b/src/main/java/wj/flab/group_wise/service/event/GroupPurchaseEventListener.java
@@ -2,8 +2,10 @@ package wj.flab.group_wise.service.event;
 
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import wj.flab.group_wise.domain.Notification;
 import wj.flab.group_wise.domain.Notification.DeliveryChannel;
 import wj.flab.group_wise.domain.Notification.NotificationType;
@@ -21,7 +23,8 @@ public class GroupPurchaseEventListener {
 
     private final NotificationService notificationService;
 
-    @EventListener
+    @Async("notificationTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGroupPurchaseStartedEvent(GroupPurchaseStartedEvent event) {
 
         GroupPurchase groupPurchase = event.getGroupPurchase();
@@ -39,7 +42,8 @@ public class GroupPurchaseEventListener {
         );
     }
 
-    @EventListener
+    @Async("notificationTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMinimumParticipantsMetEvent(MinimumParticipantsMetEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
         Long groupPurchaseId = groupPurchase.getId();
@@ -75,12 +79,14 @@ public class GroupPurchaseEventListener {
     }
 
     // 최소 인원 미달 상태 알림 처리
-    @EventListener
+    @Async("notificationTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMinimumParticipantsUnmet(MinimumParticipantsUnmetEvent event) {
         // todo : 공동구매별로 이전에 최소 인원수 달성했었는지 여부를 확인할 수 있는 필드 추가가 필요함
     }
 
-    @EventListener
+    @Async("notificationTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGroupPurchaseSuccessEvent(GroupPurchaseSuccessEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
         Long groupPurchaseId = groupPurchase.getId();
@@ -115,7 +121,8 @@ public class GroupPurchaseEventListener {
         // 주문 생성 로직 추가
     }
 
-    @EventListener
+    @Async("notificationTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGroupPurchaseFailureEvent(GroupPurchaseFailureEvent event) {
         GroupPurchase groupPurchase = event.getGroupPurchase();
         Long groupPurchaseId = groupPurchase.getId();

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,7 @@ spring:
         format_sql: true
         highlight_sql: true        # SQL 하이라이트 추가
         use_sql_comments: true     # JPQL 쿼리 주석 추가
+        default_batch_fetch_size: 100
     #        javax.persistence.schema-validation.before-flyway: false
   flyway:
     enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,6 +16,7 @@ spring:
       hibernate:
         format_sql: false
         use_sql_comments: false
+        default_batch_fetch_size: 100
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,6 +16,7 @@ spring:
         format_sql: true
         highlight_sql: true        # SQL 하이라이트 추가
         use_sql_comments: true     # JPQL 쿼리 주석 추가
+        default_batch_fetch_size: 100
     #        javax.persistence.schema-validation.before-flyway: false
   flyway:
     enabled: false


### PR DESCRIPTION
작업내용:
- jpa 글로벌 배치 페이 사이즈 설정했습니다.
- 공동구매 게시물 상태 변경 알림을 위한 이벤트 리스너를 개선했습니다.
  - 비동기로 변경
  - 트랜젝션 실행단계 변경
  - 다수 참여자/관심자에게 알림을 병렬 스트림으로 처리
  - Notification 클래스내에 정적 팩토리 메서드 추가